### PR TITLE
k increment correction

### DIFF
--- a/Chapter2/Exercise 2-04/squeeze.c
+++ b/Chapter2/Exercise 2-04/squeeze.c
@@ -54,8 +54,9 @@ void squeeze(char s1[], char s2[])
         while (s1[j] != '\0') {
             if (s1[j] == s2[i]) {
                 k = j;
-                while ((s1[k] = s1[++k]) != '\0')
-                    ;
+                while ((s1[k] = s1[k + 1]) != '\0'){
+                    ++k;
+                }
             } else
                 ++j;
         }


### PR DESCRIPTION
Fixed so that s1[k  +1] evaluates to the next char in array s1 then increment k in the while loop. Previous implementation would evaluate s1[] then increment k. Important to note that s1[++k] will evaluate as s1[k] then increment k, this is not the desired intent.