### PR TITLE
Repair squeeze.c

### DIFF
--- a/Chapter2/Exercise 2-04/squeeze.c
+++ b/Chapter2/Exercise 2-04/squeeze.c
@@ -46,19 +46,15 @@ int get_line(char s[], int lim)
 /* This implementation is a bit more complicated*/
 void squeeze(char s1[], char s2[])
 {
-    int i, j, k;
+    int i;
+    int j;
+    int k;
 
-    i = 0;
-    while (s2[i] != '\0') {
-        j = 0;
-        while (s1[j] != '\0') {
-            if (s1[j] == s2[i]) {
-                k = j;
-                while ((s1[k] = s1[++k]) != '\0')
-                    ;
-            } else
-                ++j;
-        }
-        ++i;
+    for (k = 0; s2[k] != '\0'; ++k) {
+        for (i = j = 0; s1[i] != '\0'; i++)
+            if (s1[i] != s2[k])
+                s1[j++] = s1[i];
+
+        s1[j] = '\0';
     }
 }


### PR DESCRIPTION
The original implementation resulted in an infinite loop using GCC 9.1.0 on Linux x86_64. I have made changes that (I believe) produce correct output and are slightly more succinct. 

```
Input string s1:
abracadabra
Input string s2:
abc
Result is rdr
```