### PR TITLE
Repair expand.c for "a-b-c" edge case.

### DIFF
--- a/Chapter3/Exercise 3-03/expand.c
+++ b/Chapter3/Exercise 3-03/expand.c
@@ -49,9 +49,9 @@ void expand(char s1[], char s2[])
             ('A' <= s1[i] && s1[i] <= 'Z' && s1[i] <= c && c <= 'Z') ||
             ('0' <= s1[i] && s1[i] <= '9' && s1[i] <= c && c <= '9'))) {
                 k = 0;
-                while (k <= c - s1[i])
+                while (k < c - s1[i])
                     s2[j++] = s1[i] + k++;
-                i += 2;
+                i++;
         } else {
             s2[j++] = s1[i];
         }


### PR DESCRIPTION
For the input `a-b-c` the expansion result was previously `ab-c` whereas it is now `abc`. This input is defined as a special case that must be handled in the requirements for Exercise 3-3.

Example input:
```0- -z a-b-c a-z0-9 -a-z```
Example output:
```0- -z abc abcdefghijklmnopqrstuvwxyz0123456789 -abcdefghijklmnopqrstuvwxyz```