### PR TITLE
docs: fix simple typo, temperatuire -> temperature

### DIFF
--- a/Chapter1/Exercise 1-03/temperature.c
+++ b/Chapter1/Exercise 1-03/temperature.c
@@ -11,7 +11,7 @@ int main(void)
     float fahr, celsius;
     float lower, upper, step;
 
-    lower = 0; /* lower limit of temperatuire scale */
+    lower = 0; /* lower limit of temperature scale */
     upper = 300; /* upper limit */
     step = 20; /* step size */
 

--- a/Chapter1/Exercise 1-04/ctof.c
+++ b/Chapter1/Exercise 1-04/ctof.c
@@ -11,7 +11,7 @@ int main(void)
     float fahr, celsius;
     float lower, upper, step;
 
-    lower = -20; /* lower limit of temperatuire scale */
+    lower = -20; /* lower limit of temperature scale */
     upper = 150; /* upper limit */
     step = 10; /* step size */
 

--- a/Chapter1/Exercise 1-05/reverse_temperature.c
+++ b/Chapter1/Exercise 1-05/reverse_temperature.c
@@ -11,7 +11,7 @@ int main(void)
     float fahr, celsius;
     float lower, upper, step;
 
-    lower = 0; /* lower limit of temperatuire scale */
+    lower = 0; /* lower limit of temperature scale */
     upper = 300; /* upper limit */
     step = 20; /* step size */
 

--- a/Chapter1/Exercise 1-15/temperature.c
+++ b/Chapter1/Exercise 1-15/temperature.c
@@ -12,7 +12,7 @@ int main(void)
 {
     float fahr, celsius;
     float lower, upper, step;
-    lower = 0; /* lower limit of temperatuire scale */
+    lower = 0; /* lower limit of temperature scale */
     upper = 300; /* upper limit */
     step = 20; /* step size */
     fahr = lower;


### PR DESCRIPTION
There is a small typo in Chapter1/Exercise 1-03/temperature.c, Chapter1/Exercise 1-04/ctof.c, Chapter1/Exercise 1-05/reverse_temperature.c, Chapter1/Exercise 1-15/temperature.c.

Should read `temperature` rather than `temperatuire`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md